### PR TITLE
Various trait implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ pub type Song = U7;
 
 /// The MIDI channel. There are 16 channels. They are numbered between 1 and 16
 /// inclusive, or indexed between 0 and 15 inclusive.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Channel {
     Ch1,
     Ch2,


### PR DESCRIPTION
Thanks for the great crate! I'm using a fork of it in my project, [midiplex](https://github.com/jswrenn/midiplex), with some minor changes:
 - [Derived `PartialOrd`, `Ord`, and `Hash` for `Channel`.](https://github.com/wmedrano/wmidi/commit/0de1f704a2eb5f0877cac975bc302b6ef9614139)
   I'm using this [to map `(Note, Channel)` pairs to MIDI output connections](https://github.com/jswrenn/midiplex/blob/85801c81e5bc86583b74e81b8d133d9bd6454053/src/main.rs#L31).
 - [Implemented `Read` for `MidiMessage`.](https://github.com/wmedrano/wmidi/commit/95d4ffb770937fc415cf29244728544c561266cb)
   I'm using this [to serialize `MidiMessage`s back into bytes](https://github.com/jswrenn/midiplex/blob/master/src/main.rs#L63-L65) to avoid the overhead imposed by `MidiMessage::write`'s dynamic dispatch on its argument.

These changes are non-breaking, and so would require only a minor version bump to incorporate.