### PR TITLE
add support for no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ bench = false
 [dev-dependencies]
 criterion = "0.3"
 
+[features]
+# Meta-features:
+default = ["std"] # without "std" wmidi uses libcore
+std = []
+
 [[bench]]
 name = "bench"
 harness = false

--- a/src/byte.rs
+++ b/src/byte.rs
@@ -1,5 +1,5 @@
 use crate::Error;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 /// A data byte that holds 7 bits of information.
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -60,7 +60,6 @@ impl TryFrom<u8> for U7 {
         }
     }
 }
-
 
 /// A combination of 2 data bytes that holds 14 bits of information.
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
+use core::fmt;
+#[cfg(feature = "std")]
 use std::error;
-use std::fmt;
 
 /// Midi decoding errors.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -36,6 +37,7 @@ pub enum FromBytesError {
     U14OutOfRange,
 }
 
+#[cfg(feature = "std")]
 impl error::Error for FromBytesError {}
 
 impl fmt::Display for FromBytesError {
@@ -51,6 +53,7 @@ pub enum ToSliceError {
     BufferTooSmall,
 }
 
+#[cfg(feature = "std")]
 impl error::Error for ToSliceError {}
 
 impl fmt::Display for ToSliceError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+#![no_std]
+#![cfg(feature = "std")]
+#[macro_use]
+extern crate std;
+
 mod byte;
 mod error;
 mod midi_message;
@@ -15,6 +20,7 @@ pub use note::Note;
 pub type Error = FromBytesError;
 
 /// The frequency for `note` using the standard 440Hz tuning.
+#[cfg(feature = "std")]
 #[inline(always)]
 #[deprecated(since = "3.0.0", note = "Use note.to_freq_f32() instead.")]
 pub fn note_to_frequency_f32(note: Note) -> f32 {
@@ -22,6 +28,7 @@ pub fn note_to_frequency_f32(note: Note) -> f32 {
 }
 
 /// The frequency for `note` using the standard 440Hz tuning.
+#[cfg(feature = "std")]
 #[inline(always)]
 #[deprecated(since = "3.0.0", note = "Use note.to_freq_f64() instead.")]
 pub fn note_to_frequency_f64(note: Note) -> f64 {

--- a/src/note.rs
+++ b/src/note.rs
@@ -1,6 +1,6 @@
 use crate::Error;
-use std::convert::TryFrom;
-use std::fmt;
+use core::convert::TryFrom;
+use core::fmt;
 
 /// A midi note.
 ///
@@ -220,7 +220,7 @@ impl Note {
     ///```
     #[inline(always)]
     pub unsafe fn from_u8_unchecked(note: u8) -> Note {
-        std::mem::transmute(note)
+        core::mem::transmute(note)
     }
 
     /// The frequency using the standard 440Hz tuning.
@@ -231,6 +231,7 @@ impl Note {
     /// let note = wmidi::Note::A3;
     /// sing(note.to_freq_f32());
     /// ```
+    #[cfg(feature = "std")]
     #[inline(always)]
     pub fn to_freq_f32(self) -> f32 {
         let exp = (f32::from(self as u8) + 36.376_316) / 12.0;
@@ -245,6 +246,7 @@ impl Note {
     /// let note = wmidi::Note::A3;
     /// sing(note.to_freq_f64());
     /// ```
+    #[cfg(feature = "std")]
     #[inline(always)]
     pub fn to_freq_f64(self) -> f64 {
         let exp = (f64::from(self as u8) + 36.376_316_562_295_91) / 12.0;
@@ -486,6 +488,7 @@ mod test {
         assert_eq!(Note::B3.step(-100), Err(Error::NoteOutOfRange));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_debug() {
         let debug_str = format!("{:?}", Note::Bb3);


### PR DESCRIPTION
Hello
I work on an [embedded audio](https://github.com/musitdev/satin_board) card with Rust firmware. I've developed my own little midi lib but I think it will be preferable to have one lib. There a few change to make wmidi compatible with no-std so I can use it. That this PR.
The only think badly managed is the  OwnedSysEx(Vec<U7>) that need allocation. I remove it for no-std. I'll see latter what can be done to avoid allocation and make it no-std compatible.
Std function shouldn't have been modified.
Tell me what you think.